### PR TITLE
Allow module to run on 1.4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/nbproject/private/
+/nbproject/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/nbproject/private/

--- a/lib/LDAPAuth/AbstractController.php
+++ b/lib/LDAPAuth/AbstractController.php
@@ -58,7 +58,7 @@ abstract class LDAPAuth_AbstractController extends Zikula_AbstractController
      */
     protected function getAny(array &$argArray)
     {
-        $this->get($argArray, 'any');
+        $this->getToArrayLdap($argArray, 'any');
     }
 
     /**
@@ -69,7 +69,7 @@ abstract class LDAPAuth_AbstractController extends Zikula_AbstractController
      */
     protected function getPost(array &$argArray)
     {
-        self::get($argArray, 'post');
+        $this->getToArrayLdap($argArray, 'post');
     }
 
     /**
@@ -80,7 +80,7 @@ abstract class LDAPAuth_AbstractController extends Zikula_AbstractController
      */
     protected function getGet(array &$argArray)
     {
-        $this->get($argArray, 'get');
+        $this->getToArrayLdap($argArray, 'get');
     }
 
     /**
@@ -91,7 +91,7 @@ abstract class LDAPAuth_AbstractController extends Zikula_AbstractController
      * @throws Zikula_Exception_Fatal Thrown if $argArray is not an array
      * @return void
      */
-    protected function get(array &$argArray, $option = 'any')
+    protected function getToArrayLdap(array &$argArray, $option = 'any')
     {
         if (!is_array($argArray)) {
             throw new Zikula_Exception_Fatal();
@@ -103,7 +103,7 @@ abstract class LDAPAuth_AbstractController extends Zikula_AbstractController
             $argArray[$key] = array_key_exists($key, $collection) ? $collection[$key] : $val;
         }
     }
-
+    
     /**
      * Returns a Collection of all Input Parameters.
      *

--- a/lib/LDAPAuth/Api/Authentication.php
+++ b/lib/LDAPAuth/Api/Authentication.php
@@ -157,6 +157,32 @@ class LDAPAuth_Api_Authentication extends Zikula_Api_AbstractAuthentication
     }
 
     /**
+     * Retrieves an authentication method defined by this module.
+     *
+     * Parameters passed in $args:
+     * ---------------------------
+     * string 'method' The name of the authentication method.
+     *
+     * @param array $args All arguments passed to this function.
+     *
+     * @return array An array containing the authentication method requested.
+     *
+     * @throws \InvalidArgumentException Thrown if invalid parameters are sent in $args.
+     */
+    public function getAuthenticationMethod(array $args)
+    {
+        if (!isset($args['method'])) {
+            throw new \InvalidArgumentException($this->__f('An invalid value for the \'method\' parameter was received (\'%1$s\').', array($args['method'])));
+        }
+
+        if (!isset($this->authenticationMethods[($args['method'])])) {
+            throw new \InvalidArgumentException($this->__f('The requested authentication method \'%1$s\' does not exist.', array($args['method'])));
+        }
+
+        return $this->authenticationMethods[($args['method'])];
+    }
+
+    /**
      * Registers a user account record or a user registration request with the authentication method
      *
      * @see Zikula_Api_AbstractAuthentication::register()

--- a/lib/LDAPAuth/Version.php
+++ b/lib/LDAPAuth/Version.php
@@ -35,7 +35,7 @@ class LDAPAuth_Version extends Zikula_AbstractVersion
                 'LDAPAuth::' => 'User ID::',
             ],
             'core_min' => '1.3.5', // Fixed to 1.3.x range
-            'core_max' => '1.3.99', // Fixed to 1.3.x range
+            'core_max' => '1.4.99', // Fixed to 1.4.x range
         ];
 
         return $meta;


### PR DESCRIPTION
This pull request represents the minimum changes necessary for the module in it's 1.3.x form to run in the (current) 1.4.2 release. 
One piece still not working is legal module integration. If the legal module is active, a new user can't get past the screen to accept the TOS/age etc. Even it checked they are return4ed to that page. 
